### PR TITLE
Add option to reuse pre-extracted frames

### DIFF
--- a/modules/globals.py
+++ b/modules/globals.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 WORKFLOW_DIR = os.path.join(ROOT_DIR, "workflow")
@@ -66,3 +66,9 @@ segmenter_backend: str = 'auto'
 occlusion_aware_compositing = True
 # Sensitivity 0.0 (conservative) .. 1.0 (aggressive)
 occlusion_sensitivity = 0.5
+
+# Optional override for reusing an existing directory of extracted frames.
+temp_frame_input_directory: Optional[str] = None
+# Indicates that we should avoid cleaning up temp resources because we are
+# reusing a pre-existing directory of extracted frames.
+reuse_temp_dir = False

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -175,10 +175,13 @@ def restore_audio(target_path: str, output_path: str) -> None:
 
 def get_temp_frame_paths(target_path: str) -> List[str]:
     temp_directory_path = get_temp_directory_path(target_path)
-    return glob.glob((os.path.join(glob.escape(temp_directory_path), "*.png")))
+    return sorted(glob.glob((os.path.join(glob.escape(temp_directory_path), "*.png"))))
 
 
 def get_temp_directory_path(target_path: str) -> str:
+    override = getattr(modules.globals, 'temp_frame_input_directory', None)
+    if override:
+        return override
     target_name, _ = os.path.splitext(os.path.basename(target_path))
     target_directory_path = os.path.dirname(target_path)
     return os.path.join(target_directory_path, TEMP_DIRECTORY, target_name)
@@ -214,6 +217,8 @@ def move_temp(target_path: str, output_path: str) -> None:
 
 
 def clean_temp(target_path: str) -> None:
+    if getattr(modules.globals, 'reuse_temp_dir', False):
+        return
     temp_directory_path = get_temp_directory_path(target_path)
     parent_directory_path = os.path.dirname(temp_directory_path)
     if not modules.globals.keep_frames and os.path.isdir(temp_directory_path):


### PR DESCRIPTION
## Summary
- add a `--temp-frame-dir` CLI option and store the override in globals so runs can reuse existing PNG frames
- update the processing workflow to skip extraction when an existing frame directory is supplied and validate the frame set before swapping
- ensure utility helpers honor the override path, sort frame inputs, and avoid deleting reused directories

## Testing
- python -m compileall modules

------
https://chatgpt.com/codex/tasks/task_e_68d77cc83c588329a86aea3c87672e47