### PR TITLE
Fix frame worker to process partial batches

### DIFF
--- a/modules/processors/frame/core.py
+++ b/modules/processors/frame/core.py
@@ -107,13 +107,13 @@ def multi_process_frame(
         """
         while True:
             batch: List[str] = []
-            try:
-                # Pull up to effective_batch_size items without blocking
-                for _ in range(effective_batch_size):
+            # Pull up to effective_batch_size items without blocking
+            for _ in range(effective_batch_size):
+                try:
                     batch.append(frame_queue.get_nowait())
-            except Empty:
-                # Stop filling this batch when the queue runs dry
-                break
+                except Empty:
+                    # Stop filling this batch when the queue runs dry
+                    break
 
             if not batch:
                 # No items were retrieved, so the queue was empty. Worker can exit.


### PR DESCRIPTION
## Summary
- adjust frame worker loop to retain partially dequeued frames when the queue runs dry
- ensure the last batch of frames is still passed to the processor instead of being dropped

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8f8f555788329b9bf8c2d173924e3