### PR TITLE
Add tool to package repo as a self-extracting archive

### DIFF
--- a/docs/self_extracting.md
+++ b/docs/self_extracting.md
@@ -1,0 +1,52 @@
+# Self-extracting archive
+
+This repository includes a helper script that can bundle the complete project into a
+single, self-extracting Python executable. The resulting file can be distributed so
+that end users only need to download it and execute it to unpack the code and run the
+application.
+
+## Prerequisites
+
+* Python 3.8 or newer on the machine that creates the archive.
+* The `zipfile` module is part of the Python standard library, so no extra
+  dependencies are required.
+
+## Creating the archive
+
+Run the helper script from the repository root:
+
+```bash
+python tools/create_self_extracting.py
+```
+
+By default, the script produces `dist/Deep-Live-Cam.sfx.py`. The file is marked as
+executable; you can move or rename it as needed. To choose a different output path,
+pass the `--output` flag:
+
+```bash
+python tools/create_self_extracting.py --output /path/to/Deep-Live-Cam.sfx.py
+```
+
+## How the archive works
+
+The generated script bundles the full repository (excluding caches and `.git`
+metadata) into a base64-encoded ZIP archive and embeds that data directly inside a
+Python stub. When executed:
+
+1. A temporary directory is created.
+2. The project files are extracted into that directory.
+3. If `run.py` is present it is started automatically using the same Python
+   interpreter. Otherwise the script simply reports the extraction path so you can
+   run commands manually.
+
+## Running on the target machine
+
+After distributing the archive, the recipient can run it directly with Python:
+
+```bash
+python Deep-Live-Cam.sfx.py
+```
+
+They will see the location where the files were extracted, and the application will
+launch immediately if supported on their system. The temporary extraction directory
+is not automatically removed so that the unpacked project can be inspected or reused.

--- a/tools/create_self_extracting.py
+++ b/tools/create_self_extracting.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Create a self-extracting archive of the repository."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import os
+import stat
+import zipfile
+from pathlib import Path
+from typing import Iterable
+
+EXCLUDE_DIRS = {
+    ".git",
+    ".github",
+    "__pycache__",
+    "dist",
+    "node_modules",
+    ".venv",
+}
+
+EXCLUDE_FILES = {
+    ".DS_Store",
+}
+
+STUB_TEMPLATE = """#!/usr/bin/env python3
+\"\"\"Deep-Live-Cam self-extracting archive.\"\"\"
+
+import base64
+import io
+import os
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+ENCODED_ARCHIVE = \"\"\"{encoded_data}\"\"\"
+
+
+def main() -> None:
+    archive_bytes = base64.b64decode("".join(ENCODED_ARCHIVE.split()))
+    target_dir = tempfile.mkdtemp(prefix="deeplivecam-")
+    with zipfile.ZipFile(io.BytesIO(archive_bytes)) as zf:
+        zf.extractall(target_dir)
+
+    repo_root = Path(target_dir)
+    message = (
+        "Deep-Live-Cam repository extracted to: {{path}}\n\n"
+        "You can now run the application with:\n"
+        "    python run.py\n"
+        "(Executed from the extracted repository directory.)"
+    ).format(path=repo_root)
+    print(message)
+
+    run_py = repo_root / "run.py"
+    if run_py.exists():
+        print("Launching run.py ...")
+        os.execv(sys.executable, [sys.executable, str(run_py)])
+    else:
+        print("run.py not found in the extracted repository. Exiting without execution.")
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+def iter_files(base_path: Path) -> Iterable[Path]:
+    for path in base_path.rglob("*"):
+        if path.is_dir():
+            continue
+        if any(part in EXCLUDE_DIRS for part in path.parts):
+            continue
+        if path.name in EXCLUDE_FILES:
+            continue
+        yield path
+
+
+def make_self_extracting_archive(output: Path) -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for file_path in iter_files(repo_root):
+            archive.write(file_path, file_path.relative_to(repo_root))
+
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+    formatted = "\n".join(
+        encoded[i : i + 76] for i in range(0, len(encoded), 76)
+    )
+    stub = STUB_TEMPLATE.format(encoded_data=formatted)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(stub)
+    current_mode = output.stat().st_mode
+    output.chmod(current_mode | stat.S_IEXEC)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create a self-extracting Deep-Live-Cam archive."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("dist/Deep-Live-Cam.sfx.py"),
+        help="Where to write the self-extracting archive.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    make_self_extracting_archive(args.output)
+    print(f"Self-extracting archive written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add documentation describing how to build a self-extracting Deep-Live-Cam bundle
- introduce a Python helper that packages the repository into an executable archive that auto-extracts and launches

## Testing
- python tools/create_self_extracting.py --output dist/test.sfx.py

------
https://chatgpt.com/codex/tasks/task_e_68da1e0eb8e88329828310a414f8b6dc