### PR TITLE
Add SDF-based facial mask fallback

### DIFF
--- a/modules/mask_utils.py
+++ b/modules/mask_utils.py
@@ -1,0 +1,139 @@
+"""Utility helpers for constructing smooth facial masks."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Sequence, Tuple
+
+import cv2
+import numpy as np
+
+
+def _select_skin_points(
+    kps: np.ndarray,
+    spec: str = "auto",
+    available: Optional[Iterable[int]] = None,
+) -> np.ndarray:
+    """Select a subset of facial landmarks that mostly cover skin."""
+    n = len(kps)
+    if spec == "auto":
+        spec = "468" if n >= 200 else "68"
+
+    if spec == "68":
+        idx = list(range(2, 15))
+        idx += [31, 35]
+        idx += [1, 15]
+    elif spec == "468":
+        idx = [
+            93,
+            132,
+            58,
+            172,
+            136,
+            150,
+            149,
+            176,
+            148,
+            152,
+            323,
+            361,
+            288,
+            397,
+            365,
+            379,
+            378,
+            400,
+            377,
+            383,
+            127,
+            234,
+            454,
+            227,
+            447,
+            205,
+            50,
+            280,
+            101,
+            330,
+        ]
+        idx = sorted(set(i for i in idx if 0 <= i < n))
+    else:
+        idx = list(range(n))
+
+    if available is not None:
+        avail = set(available)
+        idx = [i for i in idx if i in avail]
+        if not idx:
+            idx = list(range(n))
+    return kps[idx]
+
+
+def build_skin_sdf_mask(
+    roi_shape: Tuple[int, int],
+    kps_xy: Sequence[Sequence[float]],
+    offset_xy: Tuple[int, int] = (0, 0),
+    landmark_spec: str = "auto",
+    forehead_pad_frac: float = 0.10,
+    edge_width_px: float = 18.0,
+    inner_bias_px: float = 0.0,
+    gamma: float = 1.0,
+    min_hull_points: int = 3,
+) -> np.ndarray:
+    """Construct a smooth facial skin mask using a signed-distance field."""
+    H, W = roi_shape
+    if H <= 0 or W <= 0:
+        return np.zeros((max(H, 1), max(W, 1)), dtype=np.float32)
+
+    kps = np.asarray(kps_xy, dtype=np.float32)
+    if kps.ndim != 2 or kps.shape[1] != 2 or kps.shape[0] < min_hull_points:
+        return np.zeros((H, W), dtype=np.float32)
+
+    ox, oy = map(float, offset_xy)
+    pts = kps.copy()
+    pts[:, 0] -= ox
+    pts[:, 1] -= oy
+
+    margin = 8.0
+    in_roi = (
+        (pts[:, 0] >= -margin)
+        & (pts[:, 0] <= W + margin)
+        & (pts[:, 1] >= -margin)
+        & (pts[:, 1] <= H + margin)
+    )
+    pts = pts[in_roi]
+    if len(pts) < min_hull_points:
+        return np.zeros((H, W), dtype=np.float32)
+
+    skin_pts = _select_skin_points(pts, spec=landmark_spec)
+    if len(skin_pts) < min_hull_points:
+        skin_pts = pts
+
+    x1, y1 = np.min(skin_pts, axis=0)
+    x2, y2 = np.max(skin_pts, axis=0)
+    if forehead_pad_frac > 1e-6:
+        pad = (y2 - y1) * float(forehead_pad_frac)
+        top_mask = skin_pts[:, 1] <= (y1 + 0.35 * (y2 - y1))
+        skin_pts[top_mask, 1] = np.maximum(0.0, skin_pts[top_mask, 1] - pad)
+
+    skin_pts_i = np.round(skin_pts).astype(np.int32)
+    if len(skin_pts_i) < min_hull_points:
+        return np.zeros((H, W), dtype=np.float32)
+
+    hull = cv2.convexHull(skin_pts_i)
+    if hull is None or len(hull) < min_hull_points:
+        return np.zeros((H, W), dtype=np.float32)
+
+    inside = np.zeros((H, W), dtype=np.uint8)
+    cv2.fillConvexPoly(inside, hull, 1)
+
+    dist_in = cv2.distanceTransform(inside, distanceType=cv2.DIST_L2, maskSize=3)
+    dist_out = cv2.distanceTransform(1 - inside, distanceType=cv2.DIST_L2, maskSize=3)
+
+    sdf = dist_in - dist_out
+
+    width = max(1e-3, float(edge_width_px))
+    mask = 1.0 / (1.0 + np.exp(-(sdf - float(inner_bias_px)) / width))
+
+    if gamma != 1.0:
+        mask = np.clip(mask, 0.0, 1.0) ** float(gamma)
+
+    return mask.astype(np.float32)

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -13,6 +13,7 @@ import modules.processors.frame.core
 # If it's part of modules.core, it might already be accessible via modules.core.update_status
 from modules.core import update_status
 from modules.face_analyser import get_one_face, get_many_faces, default_source_face
+from modules.mask_utils import build_skin_sdf_mask
 from modules.typing import Face, Frame
 from modules.utilities import conditional_download, resolve_relative_path, is_image, is_video
 from modules.cluster_analysis import find_closest_centroid
@@ -534,7 +535,71 @@ def _apply_mouth_mask(original_frame: Frame, swapped_frame: Frame, target_face: 
                     pass
             return composed
 
-        # 2) Fallback: ellipse heuristic
+        # 2) Fallback: signed-distance hull mask from facial landmarks
+        has_kps = hasattr(target_face, 'kps') and target_face.kps is not None
+        if has_kps:
+            preserve_hairline = getattr(modules.globals, 'preserve_hairline', False)
+            size_scale = float(getattr(modules.globals, 'mask_size', 1.0) or 1.0)
+            feather_ratio = float(getattr(modules.globals, 'mask_feather_ratio', 8) or 8)
+
+            if hasattr(target_face, 'bbox') and target_face.bbox is not None:
+                rx1, ry1, rx2, ry2 = _expand_bbox(tuple(target_face.bbox), w, h, pad=0.08)
+            else:
+                kps = np.asarray(target_face.kps, dtype=np.float32)
+                x1, y1 = np.min(kps, axis=0)
+                x2, y2 = np.max(kps, axis=0)
+                rx1 = max(0, int(math.floor(x1)))
+                ry1 = max(0, int(math.floor(y1)))
+                rx2 = min(w, int(math.ceil(x2)))
+                ry2 = min(h, int(math.ceil(y2)))
+                if rx2 <= rx1 or ry2 <= ry1:
+                    rx1, ry1, rx2, ry2 = 0, 0, w, h
+
+            roi_o = original_frame[ry1:ry2, rx1:rx2]
+            roi_s = swapped_frame[ry1:ry2, rx1:rx2]
+            if roi_o.size and roi_s.size:
+                roi_h, roi_w = roi_s.shape[:2]
+                longest = float(max(roi_h, roi_w))
+                edge_width = max(4.0, longest / max(feather_ratio * 3.0, 1.0))
+                inner_bias = (1.0 - size_scale) * (0.08 * longest)
+                forehead_pad = 0.18 if preserve_hairline else 0.10
+
+                mask_roi = build_skin_sdf_mask(
+                    roi_shape=roi_s.shape[:2],
+                    kps_xy=target_face.kps,
+                    offset_xy=(rx1, ry1),
+                    landmark_spec='auto',
+                    forehead_pad_frac=forehead_pad,
+                    edge_width_px=edge_width,
+                    inner_bias_px=inner_bias,
+                    gamma=1.05,
+                )
+
+                if np.any(mask_roi > 0.0):
+                    mask_full = np.zeros((h, w), dtype=np.float32)
+                    mask_full[ry1:ry2, rx1:rx2] = mask_roi
+                    mask = np.clip(mask_full, 0.0, 1.0)
+                    mask_3 = np.repeat(mask[:, :, None], 3, axis=2)
+                    composed = (
+                        original_frame.astype(np.float32) * mask_3
+                        + swapped_frame.astype(np.float32) * (1.0 - mask_3)
+                    )
+                    composed = np.clip(composed, 0, 255).astype(np.uint8)
+
+                    if getattr(modules.globals, 'show_mouth_mask_box', False):
+                        try:
+                            vis = (mask_roi * 255.0).astype(np.uint8)
+                            contours, _ = cv2.findContours(
+                                vis, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+                            )
+                            cv2.drawContours(
+                                composed[ry1:ry2, rx1:rx2], contours, -1, (0, 255, 0), 2
+                            )
+                        except Exception:
+                            pass
+                    return composed
+
+        # Final safety fallback: original ellipse heuristic
         down = float(getattr(modules.globals, 'mask_down_size', 0.5) or 0.5)
         size_scale = float(getattr(modules.globals, 'mask_size', 1.0) or 1.0)
         feather_ratio = float(getattr(modules.globals, 'mask_feather_ratio', 8) or 8)
@@ -543,7 +608,6 @@ def _apply_mouth_mask(original_frame: Frame, swapped_frame: Frame, target_face: 
         ds_h = max(1, int(h * down))
         mask_small = np.zeros((ds_h, ds_w), dtype=np.float32)
 
-        has_kps = hasattr(target_face, 'kps') and target_face.kps is not None
         if has_kps:
             kps = np.array(target_face.kps, dtype=np.float32)
             lm_left = kps[3]


### PR DESCRIPTION
## Summary
- add a reusable signed-distance-field skin mask helper
- update the mouth mask fallback to use the smoother SDF mask before falling back to the old ellipse heuristic

## Testing
- python -m compileall modules/mask_utils.py modules/processors/frame/face_swapper.py

------
https://chatgpt.com/codex/tasks/task_e_68db002f37cc8329b794de42e088c83c